### PR TITLE
fix: set max duration for serverless function

### DIFF
--- a/apps/chatbot/app/api/chat/route.ts
+++ b/apps/chatbot/app/api/chat/route.ts
@@ -2,6 +2,8 @@ import { augmentedPromptChatUseCase } from "@repo/ai/features/augmentedPromptCha
 import { StreamingTextResponse } from 'ai'
 import { InvalidKeyError } from '@repo/ai/error/invalidKeyError.error'
 
+export const maxDuration = 60;
+
 export async function POST(req: Request) {
   console.log('Handling POST /api/chat');
 


### PR DESCRIPTION
This pull request configures a max duration of 60secs for the serverless function streaming the AI reponse so it doesn't stop at the middle of a sentence.

Vercel docs:
https://vercel.com/docs/functions/configuring-functions/duration#node.js-next.js-%3E=-13.5-or-higher-sveltekit-astro-nuxt-and-remix

Example issue:
![telegram-cloud-photo-size-4-5796265126133874922-y](https://github.com/cairo-book/cairo-chatbot/assets/41830259/00696f88-4547-4435-b52d-24b80ec60f4f)
