### PR TITLE
feat: load model names from env variable

### DIFF
--- a/packages/ai/features/augmentedPromptChat/ragChain.ts
+++ b/packages/ai/features/augmentedPromptChat/ragChain.ts
@@ -13,11 +13,11 @@ import { findBookChunk } from "./findBookChunk.infrastructure";
 import { DocumentInterface } from "@langchain/core/documents";
 
 const questionModel = new ChatOpenAI({
-  modelName: "gpt-3.5-turbo",
+  modelName: process.env.QUESTION_MODEL_NAME,
 });
 
 const answerModel = new ChatOpenAI({
-  modelName: "gpt-4-turbo-preview",
+  modelName: process.env.ANSWER_MODEL_NAME,
   temperature: 0.1,
 });
 


### PR DESCRIPTION
This pull request allows to change the models used via env variables. I've set the QUESTION_MODEL_NAME to gpt-3.5 (as it  was initially) but upgraded `ANSWER_MODEL_NAME` to gpt-4o as it is both cheaper and faster.